### PR TITLE
OpenBSD confirmed working

### DIFF
--- a/jcs.ijs
+++ b/jcs.ijs
@@ -465,7 +465,7 @@ i=. y i.~>1{"1 t
 servers=: 3 : 0
 p=. ;(y-:''){y;PORTS
 select. UNAME
-case. 'Linux' do.
+case. 'Linux';'OpenBSD' do.
  t=. jpath'~temp/fuser.txt'
  try.
   d=. 2!:1'fuser -n tcp ',(":p),' > "',t,'" 2>&1'
@@ -709,6 +709,8 @@ case.'Linux' do.
  ({:1".;(1 i.~(<'cpu cores')=9{.each t){t),+/(<'processor')=9{.each t
 case.'Darwin' do.
  1".(2!:0'sysctl -n hw.physicalcpu hw.logicalcpu')rplc LF;' '
+case.'OpenBSD' do.
+ 1".(2!:0'sysctl -n hw.ncpuonline hw.ncpu')rplc LF;' '
 case.'Win' do.
  2{.1".;1{<;._2 spawn_jtask_'wmic cpu get numberofcores,numberoflogicalprocessors'
 case. do.


### PR DESCRIPTION
The `net/zmq` and `net/jcs` are confirmed working with a couple minor changes.
This does rely on the `UNAME_z_` variable being set to 'OpenBSD' which will rely on this or a similar PR being merged first:
https://github.com/jsoftware/jsource/pull/111